### PR TITLE
Make minidump Python2.6 compatible

### DIFF
--- a/elfesteem/minidump.py
+++ b/elfesteem/minidump.py
@@ -9,7 +9,7 @@ class Enumeration(object):
     def __init__(self, enum_info):
         """enum_info: {name: value}"""
         self._enum_info = enum_info
-        self._inv_info = {v: k for k, v in enum_info.iteritems()}
+        self._inv_info = dict((v, k) for k, v in enum_info.iteritems())
 
     def __getitem__(self, key):
         """Helper: assume that string is for key, integer is for value"""

--- a/elfesteem/minidump_init.py
+++ b/elfesteem/minidump_init.py
@@ -134,12 +134,12 @@ class Minidump(object):
         """Build an easier to use memory view based on ModuleList and
         Memory64List streams"""
 
-        addr2module = {module.BaseOfImage: module
-                       for module in (self.modulelist.Modules if
-                                      self.modulelist else [])}
-        addr2meminfo = {memory.BaseAddress: memory
-                        for memory in (self.memoryinfolist.MemoryInfos if
-                                       self.memoryinfolist else [])}
+        addr2module = dict((module.BaseOfImage, module)
+                           for module in (self.modulelist.Modules if
+                                          self.modulelist else []))
+        addr2meminfo = dict((memory.BaseAddress, memory)
+                            for memory in (self.memoryinfolist.MemoryInfos if
+                                           self.memoryinfolist else []))
 
         mode64 = self.minidumpHDR.Flags & mp.minidumpType.MiniDumpWithFullMemory
 


### PR DESCRIPTION
Python 2.6 compatibility was loosed with Minidump, for no gain.