### PR TITLE
Debug registers are 64 bits wide for amd64 contexts

### DIFF
--- a/elfesteem/minidump.py
+++ b/elfesteem/minidump.py
@@ -395,12 +395,12 @@ class Context_AMD64(CStruct):
         ("EFlags", "u32", is_activated("CONTEXT_CONTROL")),
 
         # Debug registers
-        ("Dr0", "u32", is_activated("CONTEXT_DEBUG_REGISTERS")),
-        ("Dr1", "u32", is_activated("CONTEXT_DEBUG_REGISTERS")),
-        ("Dr2", "u32", is_activated("CONTEXT_DEBUG_REGISTERS")),
-        ("Dr3", "u32", is_activated("CONTEXT_DEBUG_REGISTERS")),
-        ("Dr6", "u32", is_activated("CONTEXT_DEBUG_REGISTERS")),
-        ("Dr7", "u32", is_activated("CONTEXT_DEBUG_REGISTERS")),
+        ("Dr0", "u64", is_activated("CONTEXT_DEBUG_REGISTERS")),
+        ("Dr1", "u64", is_activated("CONTEXT_DEBUG_REGISTERS")),
+        ("Dr2", "u64", is_activated("CONTEXT_DEBUG_REGISTERS")),
+        ("Dr3", "u64", is_activated("CONTEXT_DEBUG_REGISTERS")),
+        ("Dr6", "u64", is_activated("CONTEXT_DEBUG_REGISTERS")),
+        ("Dr7", "u64", is_activated("CONTEXT_DEBUG_REGISTERS")),
 
         # Integer registers
         # /!\ activation depends on multiple flags


### PR DESCRIPTION
Here's the CPU context dumped from the debugger:

```
0:000> r
rax=deadbeefbaadc0de rbx=0000003bc15fdb60 rcx=0000020fe9626000
rdx=0000003bc15fdb60 rsi=0000020fe9cdb098 rdi=0000003bc15fdcf0
rip=00007ff7004900cc rsp=0000003bc15fd778 rbp=0000020fe9626000
 r8=0000003bc15fdcf0  r9=0000020fe9cdb098 r10=0000020fe9d4c948
r11=0000000000000013 r12=0000020fe9626068 r13=00007ff7010724d8
r14=deadbeefbaadc0de r15=0000020fe9626000
iopl=0         nv up ei pl nz na po nc
cs=0033  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00010204
```

And here's the one dumped via elfesteem with this patch:

```
=============================CPU==============================
rax=deadbeefbaadc0de rbx=0000003bc15fdb60 rcx=0000020fe9626000
rdx=0000003bc15fdb60 rsi=0000020fe9cdb098 rdi=0000003bc15fdcf0
rip=00007ff7004900cc rsp=0000003bc15fd778 rbp=0000020fe9626000
 r8=0000003bc15fdcf0  r9=0000020fe9cdb098 r10=0000020fe9d4c948
r11=0000000000000013 r12=0000020fe9626068 r13=00007ff7010724d8
r14=deadbeefbaadc0de r15=0000020fe9626000
=============================EOF==============================
```